### PR TITLE
Change module name at go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/stretchr/testify
+module github.com/nutmeglabs/testify
 
 require (
 	github.com/davecgh/go-spew v1.1.0


### PR DESCRIPTION
The following error happens when we import this module from banda using `go mod vendor`.

```
$ go mod vendor
go: github.com/nutmeglabs/testify@v1.3.1-0.20190509232745-d23661d7605e: parsing go.mod:
        module declares its path as: github.com/stretchr/testify
                but was required as: github.com/nutmeglabs/testify
```